### PR TITLE
added re-converter for bgp listen range 'peer-group'

### DIFF
--- a/CVEOSConversion.py
+++ b/CVEOSConversion.py
@@ -197,6 +197,18 @@ def checkCli(myConfig):
 
 #passive-interface - passive
 
+#Re-Convert BGP Listen Range peer group to peer-group
+	reconvert = ''
+	for line in newConfig.splitlines():
+		if 'bgp listen range' in line:
+			print('===========================================================\n\n\n\n================LINE================\n\n\n\n===========================================================')
+			print(line)
+			line = line.replace('peer group', 'peer-group')
+			reconvert += line+'\n'
+		else:
+			reconvert += line+'\n'
+
+	newConfig = reconvert
 	return newConfig
 
 #


### PR DESCRIPTION
Added a re-converter for the 'bgp listen range' command that still has the 'peer-group' syntax.