### PR TITLE
bgp listen range fix

### DIFF
--- a/CVEOSConversion.py
+++ b/CVEOSConversion.py
@@ -201,8 +201,6 @@ def checkCli(myConfig):
 	reconvert = ''
 	for line in newConfig.splitlines():
 		if 'bgp listen range' in line:
-			print('===========================================================\n\n\n\n================LINE================\n\n\n\n===========================================================')
-			print(line)
 			line = line.replace('peer group', 'peer-group')
 			reconvert += line+'\n'
 		else:

--- a/CVEOSConversion.py
+++ b/CVEOSConversion.py
@@ -197,6 +197,18 @@ def checkCli(myConfig):
 
 #passive-interface - passive
 
+#Re-Convert BGP Listen Range peer group to peer-group
+	reconvert = ''
+	for line in newConfig.splitlines():
+		if 'bgp listen range' in line:
+			print('===========================================================\n\n\n\n================LINE================\n\n\n\n===========================================================')
+			print(line)
+			line = line.replace('peer group', 'peer-group')
+			reconvert += line+'\n'
+		else:
+			reconvert += line+'\n'
+
+	newConfig = reconvert
 	return newConfig
 
 #


### PR DESCRIPTION
More of just a callout, but this is a simple fix for this.

bgp listen range reconverter from 'peer group' back to 'peer-group' which is invalid syntax.

Checks every line in newConfig for 'bgp listen range'. If this exists, just replace 'peer group' with 'peer-group'