### PR TITLE
Update CVEOSConversion.py

### DIFF
--- a/CVEOSConversion.py
+++ b/CVEOSConversion.py
@@ -79,6 +79,7 @@ def checkCli(myConfig):
     newConfig = re.sub('peer-group', 'peer group', newConfig)
     newConfig = re.sub('bgp listen limit', 'dynamic peer max', newConfig)
     newConfig = re.sub('fall-over bfd', 'bfd', newConfig)
+    newConfig = re.sub('inbound all', 'all', newConfig)
     newConfig = re.sub('soft-reconfiguration', 'rib-in pre-policy retain', newConfig)
     newConfig = re.sub('transport connection-mode', 'passive', newConfig)
 


### PR DESCRIPTION
`soft-reconfiguration inbound all` gets changed to `rib-in pre-policy retain inbound all` which is not correct, we also need to change `inbound all` to `all`